### PR TITLE
Fix build on Mac OS X 10.7

### DIFF
--- a/mipscope.pro
+++ b/mipscope.pro
@@ -152,7 +152,10 @@ RESOURCES += src/gui/images/images.qrc \
 QT += opengl
 OBJECTS_DIR = obj
 MOC_DIR     = obj
-QMAKE_MAC_SDK=/Developer/SDKs/MacOSX10.6.sdk
-QMAKE_MACOSX_DEPLOYMENT_TARGET=10.5
-QMAKE_CXX=g++-4.2
-CONFIG+=x86_64 x86
+
+macx {
+	QMAKE_MAC_SDK                  = /Developer/SDKs/MacOSX10.6.sdk
+	QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.5
+	QMAKE_CXX                      = g++-4.2
+	CONFIG                        += x86 x86_64
+}

--- a/mipscope.pro
+++ b/mipscope.pro
@@ -152,3 +152,7 @@ RESOURCES += src/gui/images/images.qrc \
 QT += opengl
 OBJECTS_DIR = obj
 MOC_DIR     = obj
+QMAKE_MAC_SDK=/Developer/SDKs/MacOSX10.6.sdk
+QMAKE_MACOSX_DEPLOYMENT_TARGET=10.5
+QMAKE_CXX=g++-4.2
+CONFIG+=x86_64 x86


### PR DESCRIPTION
This makes Mipscope build on 10.7 again.
