### PR TITLE
mipscope.pro: Allow building on OS X before 10.6

### DIFF
--- a/mipscope.pro
+++ b/mipscope.pro
@@ -145,10 +145,3 @@ RESOURCES += src/gui/images/images.qrc \
              src/gui/plugins/maze/images/mazeImages.qrc
 OBJECTS_DIR = obj
 MOC_DIR     = obj
-
-macx {
-	QMAKE_MAC_SDK                  = /Developer/SDKs/MacOSX10.6.sdk
-	QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.5
-	QMAKE_CXX                      = g++-4.2
-	CONFIG                        += x86 x86_64
-}


### PR DESCRIPTION
MipScope builds and runs fine on OS X 10.4 PowerPC, 10.5 PowerPC, 10.6 Intel with this change.
Tested with QT 4.8.7.