### PR TITLE
Build fix

### DIFF
--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -50,6 +50,7 @@
 #include "../simulator/Statement.H"
 #include <QtGui>
 #include <QProcess>
+#include <unistd.h>
 
 Gui::Gui(QStringList args) : QMainWindow(), 
    m_options(new Options(this)), 

--- a/src/gui/plugins/maze/MazePlugin.cpp
+++ b/src/gui/plugins/maze/MazePlugin.cpp
@@ -40,6 +40,7 @@
 #include "MazeUi.H"
 #include <QtGui>
 #include <sstream>
+#include <unistd.h>
 
 #ifdef Q_OS_WIN32
 // For Sleep()


### PR DESCRIPTION
Found when building with clang on OS X 10.11 need headers for fork(2) & usleep(3).
Tested on OS X 10.4 to 10.6.